### PR TITLE
Only send NCP Messages to servers with players

### DIFF
--- a/src/main/java/com/craftapi/bungeencpnotify/hook/NotifyHook.java
+++ b/src/main/java/com/craftapi/bungeencpnotify/hook/NotifyHook.java
@@ -55,7 +55,7 @@ public class NotifyHook extends AbstractNCPHook implements IStats, ILast {
 
 		try {
 			// Send a report notification to other servers
-			BungeeRequest.sendBungeeRequest(player, BungeeNCPNotify.getGson().toJson(new PlayerReport(player.getName(), checkType, info.getTotalVl())), "Forward", "ALL", BungeeNCPNotify.getInstance().getName());
+			BungeeRequest.sendBungeeRequest(player, BungeeNCPNotify.getGson().toJson(new PlayerReport(player.getName(), checkType, info.getTotalVl())), "Forward", "ONLINE", BungeeNCPNotify.getInstance().getName());
 		} catch (IOException e) {
 		}
 


### PR DESCRIPTION
Avoid bungee caching the message and spamming servers that had no players online. When the forward target is set to "ONLINE" only servers with players online will receive the message. When it is set to "ALL", bungee will cache the message for servers without players and forwards all messages when someone joins.
